### PR TITLE
Added Polling for Garage Door State

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Configuration sample:
     "open": "./open.sh",
     "close": "./close.sh",
     "state": "./check_state.sh",
-    "status_update_delay": 15
+    "status_update_delay": 15,
+    "poll_state_delay": 20
   }
 ]
 
@@ -34,15 +35,13 @@ Field                   | Description
 **close**               | close command. Examples: `./close.sh` or `node close.js` (required)
 **state**               | state command.  Examples: `./check_state.js` or `node state.js` (required)
 **status_update_delay** | Time to have door in opening or closing state (defaults to 15 seconds)
+**poll_state_delay**    | Time between polling for the garage door's state (leave blank to disable state polling)
 
 The open, close, and state commands must return the following verbs: OPEN, CLOSED, OPENING, CLOSING.
 
 ## FAQ
 ### Can I have multiple garage doors?
 Yes! but this is a feature of homebridge, not the plugin.  Just add an additonal accessory with a different name than your other garage door.
-
-### Is there polling so that if I open my Garage door manually I will get a notification from HomeKit?
-No. Doing somehting like this, while possible, is not trivial to add.  Unfortunately, for my own use case this is not needed and is a very low priority for me to add. Don't expect this to be added anytime soon.  Pull requests for this to be added are welcome.
 
 ### Can you add 'x' feature?
 Yes, I probably could.  Will I?  Probably not.  If there is a feature you want to add, please feel free to code it yourself and submit a pull request so others can benefit.


### PR DESCRIPTION
Added an option in the accessory configuration to allow for polling the garage door's state. When configured the accessory will run the `getState` command every `poll_state_delay` seconds and update accordingly.

This should address #2 